### PR TITLE
Support VirtualBox on non-Darwin OSes

### DIFF
--- a/bin/vagrant-tramp-ssh
+++ b/bin/vagrant-tramp-ssh
@@ -13,7 +13,12 @@ then
     type="Unknown"
   fi
 else
-  type="ws"
+    # If VBoxManage exists on the PATH, assume virtualbox
+    if hash VBoxManage 2>/dev/null; then
+        type="virtualbox"
+    else
+        type="ws"
+    fi
 fi
 
 function vm_dir() {


### PR DESCRIPTION
Hi, just saw this neat project. Unfortunately it seems like it's set up to only work on OS X right now, but detecting the presence of VirtualBox on Linux seems pretty straightforward so I just added that to vagrant-tramp-ssh. I don't know if this is the right approach (I guess you could potentially have both VMWare and VirtualBox on a Linux host?) but at the least it makes it work for me.
