### PR TITLE
Add define-obsolete-function-alias 'vagrant-tramp-enable

### DIFF
--- a/vagrant-tramp.el
+++ b/vagrant-tramp.el
@@ -133,6 +133,9 @@ not reported to be running."
   "Default list of (FUNCTION FILE) pairs to complete vagrant method.")
 
 ;;;###autoload
+(define-obsolete-function-alias 'vagrant-tramp-enable 'vagrant-tramp-add-method)
+
+;;;###autoload
 (eval-after-load 'tramp
   '(progn
      (vagrant-tramp-add-method)


### PR DESCRIPTION
`vagrant-tramp-enable` is gone, I was confused. ／(^o^)＼

see http://www.gnu.org/software/emacs/manual/html_node/elisp/Obsolete-Functions.html
