### PR TITLE
Changed concatenation pattern

### DIFF
--- a/bin/vagrant-tramp-ssh
+++ b/bin/vagrant-tramp-ssh
@@ -30,7 +30,7 @@
 
 read dir_name name <<<\
      $(echo $1 \
-              | awk -F_ '{ print $1; print $2 }')
+              | awk -F\/ '{ print $1; print $2 }')
 if [[ ! $name ]]; then name="default"; fi
 
 read id dir <<<\

--- a/vagrant-tramp.el
+++ b/vagrant-tramp.el
@@ -75,7 +75,7 @@ basename and the VM name (excluding 'default')."
   (let ((name (cdr (assoc 'name box))))
     (concat (file-name-base (cdr (assoc 'dir box)))
             (unless (string= name "default")
-              (concat "_" name)))))
+              (concat "/" name)))))
 
 (defun vagrant-tramp--running-boxes ()
   "List as per `vagrant-tramp--all-boxes', but excluding boxes


### PR DESCRIPTION
Changed concactenation pattern and shell script to use slash character (/) instead of underscore character (_) because slashes are illegal in unix file names, whereas underscores are not. I'm not sure if this breaks other parts of the program, I don't see why it should, but please try it against your tests. Thank you for your time.