### PR TITLE
Fix equality test in vagrant-tramp-ssh

### DIFF
--- a/bin/vagrant-tramp-ssh
+++ b/bin/vagrant-tramp-ssh
@@ -28,9 +28,10 @@
 ## for more details.
 
 
-read dir_name name <<<\
+read name dir_name <<<\
      $(echo $1 \
-              | awk -F_ '{ print $1; print $2 }')
+              | awk -F_ '{print $NF; NF--; gsub(/ /, "_", $0); print $0}')
+
 if [[ ! $name ]]; then name="default"; fi
 
 read id dir <<<\

--- a/bin/vagrant-tramp-ssh
+++ b/bin/vagrant-tramp-ssh
@@ -37,6 +37,6 @@ read id dir <<<\
      $(vagrant global-status \
               | awk -v name=$name \
                     -v dir=$dir_name \
-                    "\$2=name && \$5~dir { print \$1; print \$5 }")
+                    "\$2==name && \$5~dir { print \$1; print \$5 }")
 cd "$dir"
 vagrant ssh $id


### PR DESCRIPTION
This should resolve issues where a Vagrantfile generates multiple named
boxes.