### PR TITLE
Force rebuild of $0 for issue #28

### DIFF
--- a/bin/vagrant-tramp-ssh
+++ b/bin/vagrant-tramp-ssh
@@ -30,7 +30,7 @@
 
 read name dir_name <<<\
      $(echo $1 \
-              | awk -F_ '{print $NF; NF--; gsub(/ /, "_", $0); print $0}')
+              | awk -F_ '{print $NF; NF--; $1 = $1; gsub(/ /, "_", $0); print $0}')
 
 if [[ ! $name ]]; then name="default"; fi
 


### PR DESCRIPTION
Sometimes $0 is rebuilt when $NF is decremented (i.e $NF--).  However, not all awk implementations do this. To force a rebuild of $0 simply reassign a variable (i.e. $1 = $1). 

This is the solution for issue #28.