### PR TITLE
Maintenance

### DIFF
--- a/bin/vagrant-tramp-ssh
+++ b/bin/vagrant-tramp-ssh
@@ -27,10 +27,7 @@
 ## establishing a connection to a Vagrant box. See vagrant-tramp.el
 ## for more details.
 
-
-read name dir_name <<<\
-     $(echo $1 \
-              | awk -F_ '{print $NF; NF--; gsub(/ /, "_", $0); print $0}')
+read dir_name name <<< $(echo $1 | sed "s/--/\n/")
 
 if [[ ! $name ]]; then name="default"; fi
 

--- a/bin/vagrant-tramp-ssh
+++ b/bin/vagrant-tramp-ssh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 ### vagrant-tramp-ssh --- connect to the named vagrant box
 
-## Copyright © 2015 Vagrant-Tramp Contributors
+## Copyright © 2016  The Vagrant-Tramp Contributors
 
 ## Author: Ryan Prior <ryanprior@gmail.com>
 

--- a/bin/vagrant-tramp-ssh
+++ b/bin/vagrant-tramp-ssh
@@ -27,7 +27,8 @@
 ## establishing a connection to a Vagrant box. See vagrant-tramp.el
 ## for more details.
 
-read dir_name name <<< $(echo $1 | sed "s/--/\n/")
+read dir_name name <<< $(echo $1 | sed 's/--/\
+/')
 
 if [[ ! $name ]]; then name="default"; fi
 

--- a/bin/vagrant-tramp-ssh
+++ b/bin/vagrant-tramp-ssh
@@ -27,19 +27,19 @@
 ## establishing a connection to a Vagrant box. See vagrant-tramp.el
 ## for more details.
 
-read dir_name name <<< $(echo $1 | sed 's/--/\
+read dir_name name <<< $(echo "$1" | sed 's/--/\
 /')
 
-if [[ ! $name ]]; then name="default"; fi
+if [[ ! "$name" ]]; then name="default"; fi
 
 read id dir <<<\
      $(vagrant global-status --machine-readable \
            | head -n-2 | tail -n+8 \
            | cut -d, -f5- \
            | awk -v RS="" \
-                 -v name=$name \
-                 -v dir=$dir_name \
+                 -v name="$name" \
+                 -v dir="$dir_name" \
                  "\$2==name && \$5~dir { print \$1; print \$5 }")
 
 cd "$dir"
-vagrant ssh $id
+vagrant ssh "$id"

--- a/bin/vagrant-tramp-ssh
+++ b/bin/vagrant-tramp-ssh
@@ -35,9 +35,13 @@ read name dir_name <<<\
 if [[ ! $name ]]; then name="default"; fi
 
 read id dir <<<\
-     $(vagrant global-status \
-              | awk -v name=$name \
-                    -v dir=$dir_name \
-                    "\$2==name && \$5~dir { print \$1; print \$5 }")
+     $(vagrant global-status --machine-readable \
+           | head -n-2 | tail -n+8 \
+           | cut -d, -f5- \
+           | awk -v RS="" \
+                 -v name=$name \
+                 -v dir=$dir_name \
+                 "\$2==name && \$5~dir { print \$1; print \$5 }")
+
 cd "$dir"
 vagrant ssh $id

--- a/vagrant-tramp.el
+++ b/vagrant-tramp.el
@@ -1,8 +1,8 @@
 ;;; vagrant-tramp.el --- Vagrant method for TRAMP
 
-;; Copyright © 2015  The Vagrant-Tramp Contributors
+;; Copyright © 2016  The Vagrant-Tramp Contributors
 
-;; Version: 0.5.0
+;; Version: 0.6.0
 ;; Author: Doug MacEachern <dougm@vmware.com>
 ;;         Ryan Prior      <ryanprior@gmail.com> (rewrite)
 

--- a/vagrant-tramp.el
+++ b/vagrant-tramp.el
@@ -74,7 +74,7 @@
   (let ((name (cdr (assoc 'name box))))
     (concat (file-name-base (cdr (assoc 'dir box)))
             (unless (string= name "default")
-              (concat "_" name)))))
+              (concat "--" name)))))
 
 (defun vagrant-tramp--running-boxes ()
   "List as per `vagrant-tramp--all-boxes', but excluding boxes not reported to be running."

--- a/vagrant-tramp.el
+++ b/vagrant-tramp.el
@@ -50,7 +50,7 @@
                              (or load-file-name
                                  buffer-file-name))
                             "bin/vagrant-tramp-ssh")))
-  "TRAMP login helper script")
+  "TRAMP login helper script.")
 
 (defun vagrant-tramp--all-boxes ()
   "List of VMs per `vagrant global-status` as alists."
@@ -70,29 +70,27 @@
   (string= (cdr (assoc 'state box)) "running"))
 
 (defun vagrant-tramp--box-name (box)
-  "String representing BOX, using the Vagrantfile directory
-basename and the VM name (excluding 'default')."
+  "String representing BOX, using the Vagrantfile directory basename and the VM name (excluding 'default')."
   (let ((name (cdr (assoc 'name box))))
     (concat (file-name-base (cdr (assoc 'dir box)))
             (unless (string= name "default")
               (concat "_" name)))))
 
 (defun vagrant-tramp--running-boxes ()
-  "List as per `vagrant-tramp--all-boxes', but excluding boxes
-not reported to be running."
+  "List as per `vagrant-tramp--all-boxes', but excluding boxes not reported to be running."
   (-filter 'vagrant-tramp--box-running-p
            (vagrant-tramp--all-boxes)))
 
 ;;;###autoload
 (defun vagrant-tramp--completions (&optional file)
-  "List for vagrant tramp completion. FILE argument is ignored."
+  "List for vagrant tramp completion.  FILE argument is ignored."
   (--map (list nil it)
          (-map 'vagrant-tramp--box-name
                (vagrant-tramp--running-boxes))))
 
 ;;;###autoload
 (defun vagrant-tramp-term (box-name)
-  "SSH into BOX using an `ansi-term'."
+  "SSH into BOX-NAME using an `ansi-term'."
   (interactive
    (list
     (let* ((boxes (vagrant-tramp--running-boxes))

--- a/vagrant-tramp.el
+++ b/vagrant-tramp.el
@@ -54,16 +54,16 @@
 
 (defun vagrant-tramp--all-boxes ()
   "List of VMs per `vagrant global-status` as alists."
-  (let* ((status-cmd "vagrant global-status")
+  (let* ((status-cmd "vagrant global-status --machine-readable")
          (status-raw (shell-command-to-string status-cmd))
-         (status-raw-lines (split-string status-raw "\n"))
-         (status-raw-vms (--take-while (not (string= it " "))
-                                       (cddr status-raw-lines)))
-         (vm-strings (--map (--remove (string= it "")
-                                      (split-string it " "))
-                            status-raw-vms))
+         (status-lines (-drop 8 (split-string status-raw "\n")))
+         (status-data-raw (--map (mapconcat 'identity
+                                            (-drop 4 (split-string it ",")) ",")
+                                 status-lines))
+         (status-data (--map (replace-regexp-in-string " " "" it) status-data-raw))
+         (status-groups (-butlast (-split-on "" status-data)))
          (vm-attrs '(id name provider state dir)))
-    (--map (-zip vm-attrs it) vm-strings)))
+    (--map (-zip vm-attrs it) status-groups)))
 
 (defun vagrant-tramp--box-running-p (box)
   "True if BOX is reported as running."


### PR DESCRIPTION
This pull introduces two changes:

1. the separator between folder and vm name is now -- instead of _, in hopes of fewer collisions
2. we now use `vagrant global-status --machine-readable`

This should resolve #28 and by extension #29.