### PR TITLE
fix head on mac os x

### DIFF
--- a/bin/vagrant-tramp-ssh
+++ b/bin/vagrant-tramp-ssh
@@ -34,7 +34,7 @@ if [[ ! "$name" ]]; then name="default"; fi
 
 read id dir <<<\
      $(vagrant global-status --machine-readable \
-           | head -n-2 | tail -n+8 \
+           | sed '$d' | sed '$d' | tail -n+8 \
            | cut -d, -f5- \
            | awk -v RS="" \
                  -v name="$name" \

--- a/vagrant-tramp.el
+++ b/vagrant-tramp.el
@@ -97,7 +97,7 @@
            (names (-map 'vagrant-tramp--box-name boxes)))
       (if (eq 1 (length names))
           (car names)
-        (ido-completing-read "vagrant ssh to: " names)))))
+        (completing-read "vagrant ssh to: " names)))))
   (let* ((name (concat "vagrant terminal:" box-name))
          (buffer (get-buffer-create (concat "*" name "*"))))
     (unless (term-check-proc buffer)


### PR DESCRIPTION
standard mac head is not supporting the other syntax
sed works
just use completing-read (and user custom) instead of hard ido
