### PR TITLE
Update vagrant-tramp.el

### DIFF
--- a/vagrant-tramp.el
+++ b/vagrant-tramp.el
@@ -56,7 +56,7 @@
   "List of VMs per `vagrant global-status` as alists."
   (let* ((status-cmd "vagrant global-status --machine-readable")
          (status-raw (shell-command-to-string status-cmd))
-         (status-lines (-drop 8 (split-string status-raw "\n")))
+         (status-lines (-drop 7 (split-string status-raw "\n")))
          (status-data-raw (--map (mapconcat 'identity
                                             (-drop 4 (split-string it ",")) ",")
                                  status-lines))


### PR DESCRIPTION
Filter just the headers, i.e., preserve the id of the first machine.

My version os vagrant is: 1.9.1.
According to following site:
https://www.vagrantup.com/docs/cli/machine-readable.html
They will ensure backward compatibility in this command, so I expect the problem
persist regardless of the vagrant version.

You can find more info in the link below:
https://www.youtube.com/watch?v=AcpoKlFcDwM&feature=youtu.be
