### PR TITLE
Adjusted read line; correctly populates name and dir_name vars

### DIFF
--- a/bin/vagrant-tramp-ssh
+++ b/bin/vagrant-tramp-ssh
@@ -27,8 +27,7 @@
 ## establishing a connection to a Vagrant box. See vagrant-tramp.el
 ## for more details.
 
-read dir_name name <<< $(echo "$1" | sed 's/--/\
-/')
+read -d "\n" dir_name name <<< $(echo "$1" | sed $'s/--/\\\n/')
 
 if [[ ! "$name" ]]; then name="default"; fi
 


### PR DESCRIPTION
@max-arnold 's adjusted read line from #33 . It worked on his Mac, and it works on my Debian box.

The argument passed into the shell script is of the form "directoryName--boxName". Sed replaces the double hyphen with a newline character. The read command uses the newline delimiter to split the string into separate dir_name and name variables. Once populated, the awk black magic that references those variables works and the call to vagrant ssh launches successfully. 