### PR TITLE
Fixing vagrant box parsing for newer vagrant versions

### DIFF
--- a/vagrant-tramp.el
+++ b/vagrant-tramp.el
@@ -56,7 +56,8 @@
   "List of VMs per `vagrant global-status` as alists."
   (let* ((status-cmd "vagrant global-status --machine-readable")
          (status-raw (shell-command-to-string status-cmd))
-         (status-lines (-drop 7 (split-string status-raw "\n")))
+         (status-lines (-drop 1 (seq-drop-while (lambda (elt) (not (string-match-p "^.*-----------------------------------------------------------------------------------$" elt)))
+                                                (split-string status-raw "\n"))))
          (status-data-raw (--map (mapconcat 'identity
                                             (-drop 4 (split-string it ",")) ",")
                                  status-lines))


### PR DESCRIPTION
On newer vagrant versions i wasn't able to get `vagrant-tramp` to correctly auto-complete my boxes.

Did some debugging and found that number of lines to cut from the `vagrant globa-status --machine-readable` output was hard coded. Guessing this changed over time.

Instead i've adjusted that part of the code to look for the magic string `-----------------------------------------------------------------------------------` and start parsing machine details after that.